### PR TITLE
Quantiles fix

### DIFF
--- a/spot-ml/src/test/scala/org/apache/spot/QuantilesTest.scala
+++ b/spot-ml/src/test/scala/org/apache/spot/QuantilesTest.scala
@@ -14,7 +14,7 @@ class QuantilesTest extends TestingSparkContextFlatSpec with Matchers {
 
 
   "ecdf" should "work on an empty list" in {
-    val rddIn: RDD[Double] = sparkContext.parallelize(List())
+    val rddIn: RDD[Double] = sparkContext.parallelize(List(), numSlices = 3)
     val rddOut = Quantiles.computeEcdf(rddIn)
 
     val out = rddOut.collect()
@@ -23,7 +23,7 @@ class QuantilesTest extends TestingSparkContextFlatSpec with Matchers {
   }
 
   "ecdf" should "work on a constant list" in {
-    val rddIn = sparkContext.parallelize(allOnes)
+    val rddIn = sparkContext.parallelize(allOnes, numSlices = 3)
     val rddOut = Quantiles.computeEcdf(rddIn)
 
     val out = rddOut.collect()
@@ -33,7 +33,7 @@ class QuantilesTest extends TestingSparkContextFlatSpec with Matchers {
   }
 
   "ecdf" should "work on a split 50/50 list" in {
-    val rddIn = sparkContext.parallelize(onesAndTwos)
+    val rddIn = sparkContext.parallelize(onesAndTwos, numSlices = 3)
     val rddOut = Quantiles.computeEcdf(rddIn)
 
     val out = rddOut.collect()
@@ -44,7 +44,7 @@ class QuantilesTest extends TestingSparkContextFlatSpec with Matchers {
   }
 
   "ecdf" should "work on count-to-ten list" in {
-    val rddIn = sparkContext.parallelize(countToTen)
+    val rddIn = sparkContext.parallelize(countToTen, numSlices = 3)
     val rddOut = Quantiles.computeEcdf(rddIn)
 
     val out = rddOut.collect()
@@ -63,7 +63,7 @@ class QuantilesTest extends TestingSparkContextFlatSpec with Matchers {
   }
 
   "quantiles" should "work on an empty list" in {
-    val rddIn: RDD[Double] = sparkContext.parallelize(List())
+    val rddIn: RDD[Double] = sparkContext.parallelize(List(), numSlices = 3)
     val quantiles = Array(0.0, 0.5)
     val out = Quantiles.computeQuantiles(rddIn, quantiles)
 
@@ -73,7 +73,7 @@ class QuantilesTest extends TestingSparkContextFlatSpec with Matchers {
   }
 
   "quantiles" should "work on all ones list" in {
-    val rddIn = sparkContext.parallelize(allOnes)
+    val rddIn = sparkContext.parallelize(allOnes, numSlices = 3)
     val quantiles = Array(0.0, 0.5)
     val out = Quantiles.computeQuantiles(rddIn, quantiles)
 
@@ -83,7 +83,7 @@ class QuantilesTest extends TestingSparkContextFlatSpec with Matchers {
   }
 
   "quantiles" should "work on a 50/50 1s and 2s list" in {
-    val rddIn = sparkContext.parallelize(onesAndTwos)
+    val rddIn = sparkContext.parallelize(onesAndTwos, numSlices = 3)
     val quantiles = Array(0.0, 0.5)
     val out = Quantiles.computeQuantiles(rddIn, quantiles)
 
@@ -93,7 +93,7 @@ class QuantilesTest extends TestingSparkContextFlatSpec with Matchers {
   }
 
   "quantiles" should "work on a 50/50 1s and 2s list with unbalanced thresholds" in {
-    val rddIn = sparkContext.parallelize(onesAndTwos)
+    val rddIn = sparkContext.parallelize(onesAndTwos, numSlices = 3)
     val quantiles = Array(0.0, 0.6, 0.99)
     val out = Quantiles.computeQuantiles(rddIn, quantiles)
 
@@ -104,7 +104,7 @@ class QuantilesTest extends TestingSparkContextFlatSpec with Matchers {
   }
 
   "quantiles" should "work on a count-to-ten list" in {
-    val rddIn = sparkContext.parallelize(countToTen)
+    val rddIn = sparkContext.parallelize(countToTen, numSlices = 3)
     val quantiles = Array(0.0, 0.5)
     val out = Quantiles.computeQuantiles(rddIn, quantiles)
 
@@ -115,7 +115,7 @@ class QuantilesTest extends TestingSparkContextFlatSpec with Matchers {
   }
 
   "deciles" should "work on a count-to-ten list" in {
-    val rddIn = sparkContext.parallelize(countToTen)
+    val rddIn = sparkContext.parallelize(countToTen, numSlices = 3)
     val out = Quantiles.computeDeciles(rddIn)
 
     out.length shouldBe 10
@@ -132,7 +132,7 @@ class QuantilesTest extends TestingSparkContextFlatSpec with Matchers {
   }
 
   "quintiles" should "work on a count-to-ten list" in {
-    val rddIn = sparkContext.parallelize(countToTen)
+    val rddIn = sparkContext.parallelize(countToTen, numSlices = 3)
     val out = Quantiles.computeQuintiles(rddIn)
 
     out.length shouldBe 5


### PR DESCRIPTION
Fix for quantiles calculation.

Quantiles are now stable between passes over the data and between runs.

Updated unit tests to catch the error (eg. they pass now, but if you undo the fix, they will fail) Previously the unit tests didn't catch the error before because the default parallelism (of 1) was being used in the test harness, and that covers up bugs that are only exposed when the data is really distributed across multiple partitions.

In future, unit tests need to use non-trivial partitioning so they catch more bugs.
