### PR TITLE
Bug fix removing Kerberos authentication issue in hsfs_setup.sh of spot-setup

### DIFF
--- a/spot-setup/hdfs_setup.sh
+++ b/spot-setup/hdfs_setup.sh
@@ -7,8 +7,8 @@ source /etc/spot.conf
 #
 # creating HDFS user's folder
 #
-sudo -u hdfs hadoop fs -mkdir ${HUSER}
-sudo -u hdfs hadoop fs -chown ${USER}:supergroup ${HUSER}
+hadoop fs -mkdir ${HUSER}
+hadoop fs -chown ${USER}:supergroup ${HUSER}
 
 for d in "${DSOURCES[@]}" 
 do 


### PR DESCRIPTION
Deleted 'sudo -u hdfs' in lines 10 and 11 of hdfs_setup.sh in order to remove a conflict in a Kerborized environment due to running a command from a user with no Kerboros ticket. The commands that follow the deleted entries run fine coming from the solution user.
