### PR TITLE
Spot oa geoloc update

### DIFF
--- a/spot-oa/oa/flow/flow_conf.json
+++ b/spot-oa/oa/flow/flow_conf.json
@@ -33,14 +33,6 @@
 		,"ibyt":8
 		,"score":9
 		,"rank":10
-		,"srcIpInternal":11
-		,"destIpInternal":12
-		,"srcGeo":13
-		,"dstGeo":14
-		,"srcDomain":15
-		,"dstDomain":16
-		,"srcIP_rep":17
-		,"dstIP_rep":18
 	},
 	"flow_feedback_fields": {
 		"sev":0

--- a/spot-oa/oa/flow/ipynb_templates/Threat_Investigation_master.ipynb
+++ b/spot-oa/oa/flow/ipynb_templates/Threat_Investigation_master.ipynb
@@ -3,7 +3,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "import struct, socket\n",
@@ -48,7 +50,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# Widget styles and initialization\n",
@@ -125,7 +129,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "top_inbound_b='' \n",
@@ -205,7 +211,7 @@
     "                \"as avgPkts, max(ibyt) as maxBytes, avg(ibyt) as avgBytes FROM \"+DBNAME+\".flow WHERE \" + \n",
     "                \"y=\"+ date[0:4] +\" AND m=\"+ date[4:6] +\" AND d=\"+ date[6:] +\" \" + \n",
     "                \" AND (sip =\\'\" + anchor + \"\\'  OR dip=\\'\" + anchor + \"\\') GROUP BY sip, dip,sport,dport\\\" \") \n",
-    "                !impala-shell -i $IMPALA_DEM -q \"INVALIDATE METADATA\"\n",
+    "                !impala-shell -i $IMPALA_DEM --quiet -q \"INVALIDATE METADATA\"\n",
     "                !impala-shell -i $IMPALA_DEM --quiet --print_header -B --output_delimiter='\\t' -q $imp_query -o $ir_f\n",
     "            clear_output()\n",
     "            \n",
@@ -261,7 +267,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "def details_inbound(anchor, inbound, outbound, twoway):\n",
@@ -279,8 +287,9 @@
     "            + \"(sip IN({0}) \"\n",
     "            + \"AND dip ='{1}')) GROUP BY sip, dip, proto, sport, dport, ipkt, ibyt ORDER BY tstart \\\" \")  \n",
     "        ips = \"'\" + \"','\".join(top_keys) + \"'\"\n",
-    "        imp_query = imp_query.format(ips,anchor) \n",
-    "        !impala-shell -i $IMPALA_DEM -r --quiet --print_header -B --output_delimiter='\\t' -q $imp_query -o $sbdet_f\n",
+    "        imp_query = imp_query.format(ips,anchor)\n",
+    "        !impala-shell -i $IMPALA_DEM --quiet -q \"INVALIDATE METADATA\"\n",
+    "        !impala-shell -i $IMPALA_DEM --quiet --print_header -B --output_delimiter='\\t' -q $imp_query -o $sbdet_f\n",
     "\n",
     "        clear_output()\n",
     "        return \"Timeline successfully created <br/>\"\n",
@@ -734,7 +743,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [],
    "source": [
     "start_investigation()"
@@ -750,7 +761,7 @@
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2.0
+    "version": 2
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",


### PR DESCRIPTION
- Removed additional columns described in flow_conf.json file, those columns were optional and there's no use in having them fixed in the schema
- At the Threat Investigation Notebook, the -r option in the impala queries was adding 2 extra rows at the begginging of the output files. I just removed the option and added an extra query to execute the Invalidate metadata command.