### PR TITLE
adding join to avoid overflow of processes, 

### DIFF
--- a/spot-ingest/pipelines/dns/worker.py
+++ b/spot-ingest/pipelines/dns/worker.py
@@ -45,6 +45,7 @@ class Worker(object):
         self._logger.info("File: {0} ".format(file))        
         p = Process(target=self._process_new_file, args=(file,))
         p.start() 
+        p.join()
 
     def _process_new_file(self,file):
 


### PR DESCRIPTION
multiprocessing is manage by the number of workers