### PR TITLE
SpotSparkLDAWrapper performance improvements.

### DIFF
--- a/spot-ml/src/main/scala/org/apache/spot/SpotLDAWrapper.scala
+++ b/spot-ml/src/main/scala/org/apache/spot/SpotLDAWrapper.scala
@@ -43,7 +43,6 @@ object SpotLDAWrapper {
              nodes: String,
              ldaImp: String,
              logger: Logger,
-             ldaOptimizer: String,
              ldaAlpha: Double,
              ldaBeta: Double,
              maxIterations: Int,
@@ -83,7 +82,6 @@ object SpotLDAWrapper {
           topicCount,
           logger,
           prgSeed,
-          ldaOptimizer,
           ldaAlpha,
           ldaBeta,
           maxIterations)

--- a/spot-ml/src/main/scala/org/apache/spot/SpotSparkLDAWrapper.scala
+++ b/spot-ml/src/main/scala/org/apache/spot/SpotSparkLDAWrapper.scala
@@ -97,7 +97,6 @@ object SpotSparkLDAWrapper {
     import sqlContext.implicits._
 
     val docToTopicMixDF = docToTopicMix.toDF(DocumentName, TopicProbabilityMix)
-    docToTopicMixDF.show()
     //Create word results from matrix: convert matrix to sequence, wordIDs back to strings, sequence of probabilities to array
     val revWordMap: Map[Int, String] = wordDictionary.map(_.swap)
 

--- a/spot-ml/src/main/scala/org/apache/spot/SpotSparkLDAWrapper.scala
+++ b/spot-ml/src/main/scala/org/apache/spot/SpotSparkLDAWrapper.scala
@@ -115,7 +115,6 @@ object SpotSparkLDAWrapper {
 
     documentDictionary.unpersist()
 
-    //val docToTopicMixDF = docToTopicMix.toDF(DocumentName, TopicProbabilityMix)
     //Create word results from matrix: convert matrix to sequence, wordIDs back to strings, sequence of probabilities to array
     val revWordMap: Map[Int, String] = wordDictionary.map(_.swap)
 

--- a/spot-ml/src/main/scala/org/apache/spot/SpotSparkLDAWrapper.scala
+++ b/spot-ml/src/main/scala/org/apache/spot/SpotSparkLDAWrapper.scala
@@ -44,7 +44,7 @@ object SpotSparkLDAWrapper {
       words.zipWithIndex.toMap
     }
 
-    val distinctDocument: Array[String] = docWordCount.map({ case SpotLDAInput(doc, _, _) => doc }).distinct.collect
+    val distinctDocument: Array[String] = docWordCount.map({ case SpotLDAInput(doc, word, count) => doc }).distinct.collect
 
     // Create document Map Index, Document for further usage
     val documentDictionary: Map[Int, String] = {

--- a/spot-ml/src/main/scala/org/apache/spot/dns/model/DNSSuspiciousConnectsModel.scala
+++ b/spot-ml/src/main/scala/org/apache/spot/dns/model/DNSSuspiciousConnectsModel.scala
@@ -207,12 +207,10 @@ object DNSSuspiciousConnectsModel {
       config.nodes,
       config.ldaImplementation,
       logger,
-      "em",
       1.02,
       1.001,
       config.ldaMaxIterations,
       Some(0xdeadbeef))
-    // config.ldaPRGSeed)
 
     // Since DNS is still broadcasting ip to topic mix, we need to convert data frame to Map[String, Array[Double]]
     val ipToTopicMix = ipToTopicMixDF

--- a/spot-ml/src/main/scala/org/apache/spot/netflow/model/FlowSuspiciousConnectsModel.scala
+++ b/spot-ml/src/main/scala/org/apache/spot/netflow/model/FlowSuspiciousConnectsModel.scala
@@ -216,12 +216,10 @@ object FlowSuspiciousConnectsModel {
       config.nodes,
       config.ldaImplementation,
       logger,
-      "em",
       1.02,
       1.001,
       config.ldaMaxIterations,
       Some(0xdeadbeef))
-    // config.ldaPRGSeed)
 
     new FlowSuspiciousConnectsModel(topicCount,
       ipToTopicMixDF,

--- a/spot-ml/src/main/scala/org/apache/spot/proxy/ProxySuspiciousConnectsModel.scala
+++ b/spot-ml/src/main/scala/org/apache/spot/proxy/ProxySuspiciousConnectsModel.scala
@@ -137,12 +137,10 @@ object ProxySuspiciousConnectsModel {
       config.nodes,
       config.ldaImplementation,
       logger,
-      "em",
       1.02,
       1.001,
       config.ldaMaxIterations,
       Some(0xdeadbeef))
-    // config.ldaPRGSeed)
 
 
     // Since Proxy is still broadcasting ip to topic mix, we need to convert data frame to Map[String, Array[Double]]

--- a/spot-ml/src/main/scala/org/apache/spot/spotldacwrapper/SpotLDACSchema.scala
+++ b/spot-ml/src/main/scala/org/apache/spot/spotldacwrapper/SpotLDACSchema.scala
@@ -7,13 +7,13 @@ object SpotLDACSchema {
 
   // modelDF columns
   val DocumentName = "document_name"
-  val DocumentId = "document_id"
+  val DocumentNumber = "document_number"
   val DocumentCount = "document_count"
   val DocumentNameWordNameWordCount = "document_word_count"
 
   val WordNameWordCount = "word_count"
   val WordName = "word_name"
-  val WordId = "word_id"
+  val WordNumber = "word_id"
 
   // documentResults
   val TopicProbabilityMix = "topic_prob_mix"

--- a/spot-ml/src/main/scala/org/apache/spot/spotldacwrapper/SpotLDACSchema.scala
+++ b/spot-ml/src/main/scala/org/apache/spot/spotldacwrapper/SpotLDACSchema.scala
@@ -13,7 +13,7 @@ object SpotLDACSchema {
 
   val WordNameWordCount = "word_count"
   val WordName = "word_name"
-  val WordNumber = "word_id"
+  val WordNumber = "word_number"
 
   // documentResults
   val TopicProbabilityMix = "topic_prob_mix"

--- a/spot-ml/src/main/scala/org/apache/spot/spotldacwrapper/SpotLDACSchema.scala
+++ b/spot-ml/src/main/scala/org/apache/spot/spotldacwrapper/SpotLDACSchema.scala
@@ -8,12 +8,16 @@ object SpotLDACSchema {
   // modelDF columns
   val DocumentName = "document_name"
   val DocumentId = "document_id"
-  val WordNameWordCount = "word_count"
   val DocumentCount = "document_count"
   val DocumentNameWordNameWordCount = "document_word_count"
 
+  val WordNameWordCount = "word_count"
+  val WordName = "word_name"
+  val WordId = "word_id"
+
   // documentResults
   val TopicProbabilityMix = "topic_prob_mix"
+  val TopicProbabilityMixArray = "topic_prob_mix_array"
 
   // wordResults
   val _0_0_0_0_0 = "0_0_0_0_0"

--- a/spot-ml/src/main/scala/org/apache/spot/spotldacwrapper/SpotLDACWrapper.scala
+++ b/spot-ml/src/main/scala/org/apache/spot/spotldacwrapper/SpotLDACWrapper.scala
@@ -96,7 +96,7 @@ object SpotLDACWrapper {
       .map(
         x=>  x.toString().replaceAll("\\[","").replaceAll("\\]","")
       )
-      .zipWithIndex.toDF(DocumentName, DocumentId)
+      .zipWithIndex.toDF(DocumentName, DocumentNumber)
 
     // Save model to HDFS and then getmerge to file system
 
@@ -261,12 +261,12 @@ object SpotLDACWrapper {
             case (documentTopicProbabilityMix, documentTopicProbabilityMixId) =>
               (getDocumentToTopicProbabilityArray(documentTopicProbabilityMix, topicCount), documentTopicProbabilityMixId)
           }
-        ).toDF(TopicProbabilityMix, DocumentId)
+        ).toDF(TopicProbabilityMix, DocumentNumber)
 
       val ipToTopicMix = topicDocumentData.join(docIndexToDocument,
-        topicDocumentData(DocumentId).equalTo(docIndexToDocument(DocumentId)))
-        .drop(topicDocumentData(DocumentId))
-        .drop(docIndexToDocument(DocumentId)).select(col(DocumentName), col(TopicProbabilityMix))
+        topicDocumentData(DocumentNumber).equalTo(docIndexToDocument(DocumentNumber)))
+        .drop(topicDocumentData(DocumentNumber))
+        .drop(docIndexToDocument(DocumentNumber)).select(col(DocumentName), col(TopicProbabilityMix))
 
       ipToTopicMix
     }

--- a/spot-ml/src/test/scala/org/apache/spot/SpotLDACWrapperTest.scala
+++ b/spot-ml/src/test/scala/org/apache/spot/SpotLDACWrapperTest.scala
@@ -85,7 +85,7 @@ class SpotLDACWrapperTest extends TestingSparkContextFlatSpec with Matchers{
     val documentDictionary = modelDF.select(col(DocumentName))
       .rdd
       .map(x=>x.toString.replaceAll("\\]","").replaceAll("\\[",""))
-      .zipWithIndex.toDF(DocumentName, DocumentId)
+      .zipWithIndex.toDF(DocumentName, DocumentNumber)
 
     model should contain ("2 0:8 3:5")
     model should contain ("1 1:4")
@@ -104,7 +104,7 @@ class SpotLDACWrapperTest extends TestingSparkContextFlatSpec with Matchers{
 
     val topicCount = 20
     val documentDictionary = sparkContext.parallelize(Array
-    (("10.10.98.123"->3), ( "66.23.45.11"->0), ( "192.168.1.1"->1 ), ("133.546.43.22" -> 2))).toDF(DocumentName,DocumentId)
+    (("10.10.98.123"->3), ( "66.23.45.11"->0), ( "192.168.1.1"->1 ), ("133.546.43.22" -> 2))).toDF(DocumentName,DocumentNumber)
 
     val topicDocumentData = Array("0.0124531442 0.0124531442 0.0124531442 0.0124531442 0.0124531442 0.0124531442 0.0124531442 " +
       "0.0124531442 0.0124531442 0.0124531442 0.0124531442 23983.5532262138 0.0124531442 0.0124531442 0.0124531442 " +

--- a/spot-ml/src/test/scala/org/apache/spot/SpotSparkLDAWrapperTest.scala
+++ b/spot-ml/src/test/scala/org/apache/spot/SpotSparkLDAWrapperTest.scala
@@ -1,18 +1,16 @@
 package org.apache.spot
 
-import breeze.linalg.DenseMatrix
 import org.apache.log4j.{Level, LogManager}
 import org.apache.spark.mllib.linalg.{Matrices, Matrix, Vector, Vectors}
 import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.Row
+import org.apache.spark.sql.{DataFrame, Row, SQLContext}
 import org.apache.spot.SpotLDAWrapper.SpotLDAInput
 import org.apache.spot.spotldacwrapper.SpotLDACSchema._
-import org.apache.spot.SpotSparkLDAWrapper.{formatSparkLDADocTopicOutput, formatSparkLDAInput, formatSparkLDAWordOutput}
+import org.apache.spot.SpotSparkLDAWrapper.{formatSparkLDADocTopicOutput, formatSparkLDAWordOutput}
 import org.apache.spot.testutils.TestingSparkContextFlatSpec
 import org.scalatest.Matchers
 
 import scala.collection.Map
-
 
 class SpotSparkLDAWrapperTest extends TestingSparkContextFlatSpec with Matchers {
 
@@ -63,7 +61,11 @@ class SpotSparkLDAWrapperTest extends TestingSparkContextFlatSpec with Matchers 
     Math.abs(1 - (dogTopicMix(0)*dogTopics(0) + dogTopicMix(1)*dogTopics(1))) should be < 0.01
   }
 
-  "formatSparkLDAInput" should "return input in RDD[(Long, Vector)] (collected as Array for testing) format. The index is the docID, values are the vectors of word occurrences in that doc" in {
+  "formatSparkLDAInput" should "return input in RDD[(Long, Vector)] (collected as Array for testing) format. The index " +
+    "is the docID, values are the vectors of word occurrences in that doc" in {
+
+    val sqlContext = new SQLContext(sparkContext)
+    import sqlContext.implicits._
 
     val documentWordData = sparkContext.parallelize(Array(SpotLDAInput("192.168.1.1", "333333_7.0_0.0_1.0", 8),
       SpotLDAInput("10.10.98.123", "1111111_6.0_3.0_5.0", 4),
@@ -72,51 +74,49 @@ class SpotSparkLDAWrapperTest extends TestingSparkContextFlatSpec with Matchers 
 
     val wordDictionary = Map("333333_7.0_0.0_1.0" -> 0, "1111111_6.0_3.0_5.0" -> 1, "-1_43_7.0_2.0_6.0" -> 2, "-1_80_6.0_1.0_1.0" -> 3)
 
-    val distinctDocument = documentWordData.map({ case SpotLDAInput(doc, word, count) => doc }).distinct.collect()
-
-    val documentDictionary: Map[Int, String] = {
-      distinctDocument
+    val documentDictionary: DataFrame = {
+      documentWordData
+        .map({ case SpotLDAInput(doc, word, count) => doc })
+        .distinct
         .zipWithIndex
-        .sortBy(_._2)
-        .map(kv => (kv._2, kv._1))
-        .toMap
+        .toDF(DocumentName, DocumentId)
     }
-    val docStrToID: Map[String, Int] = documentDictionary.map(_.swap)
 
-    val sparkLDAInput: RDD[(Long, Vector)] = SpotSparkLDAWrapper.formatSparkLDAInput(documentWordData, docStrToID, wordDictionary)
+    val sparkLDAInput: RDD[(Long, Vector)] = SpotSparkLDAWrapper.formatSparkLDAInput(documentWordData, documentDictionary, wordDictionary, sqlContext)
     val sparkLDAInArr: Array[(Long, Vector)] = sparkLDAInput.collect()
 
-    sparkLDAInArr shouldBe Array((0,Vectors.sparse(4, Array(0,3), Array(8.0,5.0))), (1,Vectors.sparse(4,Array(1),Array(4.0))), (2,Vectors.sparse(4,Array(2),Array(2.0))))
+    sparkLDAInArr shouldBe Array((0,Vectors.sparse(4, Array(0,3), Array(8.0,5.0))), (2,Vectors.sparse(4,Array(2),Array(2.0))), (1,Vectors.sparse(4,Array(1),Array(4.0))))
   }
 
   "formatSparkLDADocTopicOuptut" should "return RDD[(String,Array(Double))] after converting doc results from vector: " +
     "convert docID back to string, convert vector of probabilities to array" in {
 
+    val sqlContext = new SQLContext(sparkContext)
+    import sqlContext.implicits._
+
     val documentWordData = sparkContext.parallelize(Array(SpotLDAInput("192.168.1.1", "333333_7.0_0.0_1.0", 8),
       SpotLDAInput("10.10.98.123", "1111111_6.0_3.0_5.0", 4),
       SpotLDAInput("66.23.45.11", "-1_43_7.0_2.0_6.0", 2),
       SpotLDAInput("192.168.1.1", "-1_80_6.0_1.0_1.0", 5)))
 
-    val wordDictionary = Map("333333_7.0_0.0_1.0" -> 0, "1111111_6.0_3.0_5.0" -> 1, "-1_43_7.0_2.0_6.0" -> 2, "-1_80_6.0_1.0_1.0" -> 3)
-
-    val distinctDocument = documentWordData.map({ case SpotLDAInput(doc, word, count) => doc }).distinct.collect()
-
-    val documentDictionary: Map[Int, String] = {
-      distinctDocument
+    val documentDictionary: DataFrame = {
+      documentWordData
+        .map({ case SpotLDAInput(doc, word, count) => doc })
+        .distinct
         .zipWithIndex
-        .sortBy(_._2)
-        .map(kv => (kv._2, kv._1))
-        .toMap
+        .toDF(DocumentName, DocumentId)
     }
 
     val docTopicDist: RDD[(Long, Vector)] = sparkContext.parallelize(Array((0.toLong, Vectors.dense(0.15, 0.3, 0.5, 0.05)), (1.toLong,
       Vectors.dense(0.25, 0.15, 0.4, 0.2)), (2.toLong, Vectors.dense(0.4, 0.1, 0.3, 0.2))))
 
-    val sparkDocRes: Array[(String, Array[Double])] = formatSparkLDADocTopicOutput(docTopicDist, documentDictionary).collect()
+    val sparkDocRes: DataFrame = formatSparkLDADocTopicOutput(docTopicDist, documentDictionary, sqlContext)
 
-    sparkDocRes(0)._1 should be ("192.168.1.1")
-    sparkDocRes(1)._1 should be ("10.10.98.123")
-    sparkDocRes(2)._1 should be ("66.23.45.11")
+    val documents = sparkDocRes.select(DocumentName).map(documentName => documentName.toString.replaceAll("\\[","").replaceAll("\\]","")).collect()
+
+    documents(0) should be ("10.10.98.123")
+    documents(1) should be ("192.168.1.1")
+    documents(2) should be ("66.23.45.11")
   }
 
   "formatSparkLDAWordOutput" should "return Map[Int,String] after converting word matrix to sequence, wordIDs back to strings, and sequence of probabilities to array" in {

--- a/spot-ml/src/test/scala/org/apache/spot/SpotSparkLDAWrapperTest.scala
+++ b/spot-ml/src/test/scala/org/apache/spot/SpotSparkLDAWrapperTest.scala
@@ -23,7 +23,7 @@ class SpotSparkLDAWrapperTest extends TestingSparkContextFlatSpec with Matchers 
     val dogWorld = SpotLDAInput("pets", "dog", 999)
 
     val data = sparkContext.parallelize(Seq(catFancy, dogWorld))
-    val out = SpotSparkLDAWrapper.runLDA(sparkContext, testSqlContext, data, 2, logger, Some(0xdeadbeef), "em")
+    val out = SpotSparkLDAWrapper.runLDA(sparkContext, testSqlContext, data, 2, logger, Some(0xdeadbeef))
 
     val topicMixDF = out.docToTopicMix
 
@@ -45,7 +45,7 @@ class SpotSparkLDAWrapperTest extends TestingSparkContextFlatSpec with Matchers 
     val dogWorld = SpotLDAInput("dog world", "dog", 1)
 
     val data = sparkContext.parallelize(Seq(catFancy, dogWorld))
-    val out = SpotSparkLDAWrapper.runLDA(sparkContext, testSqlContext, data,2, logger, None, "em")
+    val out = SpotSparkLDAWrapper.runLDA(sparkContext, testSqlContext, data,2, logger, None)
 
     val topicMixDF = out.docToTopicMix
     var dogTopicMix : Array[Double] =
@@ -79,7 +79,7 @@ class SpotSparkLDAWrapperTest extends TestingSparkContextFlatSpec with Matchers 
         .map({ case SpotLDAInput(doc, word, count) => doc })
         .distinct
         .zipWithIndex
-        .toDF(DocumentName, DocumentId)
+        .toDF(DocumentName, DocumentNumber)
     }
 
     val sparkLDAInput: RDD[(Long, Vector)] = SpotSparkLDAWrapper.formatSparkLDAInput(documentWordData, documentDictionary, wordDictionary, sqlContext)
@@ -104,7 +104,7 @@ class SpotSparkLDAWrapperTest extends TestingSparkContextFlatSpec with Matchers 
         .map({ case SpotLDAInput(doc, word, count) => doc })
         .distinct
         .zipWithIndex
-        .toDF(DocumentName, DocumentId)
+        .toDF(DocumentName, DocumentNumber)
     }
 
     val docTopicDist: RDD[(Long, Vector)] = sparkContext.parallelize(Array((0.toLong, Vectors.dense(0.15, 0.3, 0.5, 0.05)), (1.toLong,


### PR DESCRIPTION
Replaces documentDictionary: Map[String, Int] with DataFrame to avoid `.collect()`.
Also, converting LDA results to DataFrame and joining with documentDictionary: DataFrame to avoid collect, re-parallelization and converting to DF since results are already distributed.

Eliminates LDA optimizer parametrization, now SpotSparkLDAWrapper will run with EM LDA optimizer only.

Finally, caching document word count to speed things up. 