### PR TITLE
User domain designation bug fix

### DIFF
--- a/spot-ml/ml_ops.sh
+++ b/spot-ml/ml_ops.sh
@@ -108,7 +108,8 @@ time spark-submit --class "org.apache.spot.SuspiciousConnects" \
   --topicword ${LPATH}/final.beta \
   --lpath ${LPATH} \
   --ldapath ${LDAPATH} \
-  --luser ${LUSER} \
+  --luser ${LUSER} \ 
+  --userdomain ${USER_DOMAIN}\
   --mpicmd ${MPI_CMD}  \
   --proccount ${PROCESS_COUNT} \
   --topiccount ${TOPIC_COUNT} \

--- a/spot-ml/ml_ops.sh
+++ b/spot-ml/ml_ops.sh
@@ -108,8 +108,8 @@ time spark-submit --class "org.apache.spot.SuspiciousConnects" \
   --topicword ${LPATH}/final.beta \
   --lpath ${LPATH} \
   --ldapath ${LDAPATH} \
-  --luser ${LUSER} \ 
-  --userdomain ${USER_DOMAIN}\
+  --luser ${LUSER} \
+  --userdomain ${USER_DOMAIN} \
   --mpicmd ${MPI_CMD}  \
   --proccount ${PROCESS_COUNT} \
   --topiccount ${TOPIC_COUNT} \

--- a/spot-ml/src/main/scala/org/apache/spot/SuspiciousConnectsArgumentParser.scala
+++ b/spot-ml/src/main/scala/org/apache/spot/SuspiciousConnectsArgumentParser.scala
@@ -89,7 +89,7 @@ object SuspiciousConnectsArgumentParser {
       action((x, c) => c.copy(localUser = x)).
       text("Local user path")
 
-    opt[String]("userDomain").required().valueName("<user domain>").
+    opt[String]("userdomain").required().valueName("<user domain>").
       action((x, c) => c.copy(userDomain = x)).
       text("Domain of spot user (example: intel)")
 

--- a/spot-ml/src/main/scala/org/apache/spot/SuspiciousConnectsArgumentParser.scala
+++ b/spot-ml/src/main/scala/org/apache/spot/SuspiciousConnectsArgumentParser.scala
@@ -19,6 +19,7 @@ object SuspiciousConnectsArgumentParser {
                                       topicCount: Int = 20,
                                       localPath: String = "",
                                       localUser: String = "",
+                                      userDomain: String = "",
                                       ldaPath: String = "",
                                       nodes: String = "",
                                       hdfsScoredConnect: String = "",
@@ -87,6 +88,10 @@ object SuspiciousConnectsArgumentParser {
     opt[String]("luser").required().valueName("<local path>").
       action((x, c) => c.copy(localUser = x)).
       text("Local user path")
+
+    opt[String]("userDomain").required().valueName("<user domain>").
+      action((x, c) => c.copy(userDomain = x)).
+      text("Domain of spot user (example: intel)")
 
     opt[String]("nodes").required().valueName("<input param>").
       action((x, c) => c.copy(nodes = x)).

--- a/spot-ml/src/main/scala/org/apache/spot/dns/DNSSuspiciousConnectsAnalysis.scala
+++ b/spot-ml/src/main/scala/org/apache/spot/dns/DNSSuspiciousConnectsAnalysis.scala
@@ -54,6 +54,8 @@ object DNSSuspiciousConnectsAnalysis {
 
     logger.info("Loading data")
 
+    val userDomain = config.userDomain
+
     val rawDataDF = sqlContext.read.parquet(config.inputPath)
       .filter(Timestamp + " is not null and " + UnixTimestamp + " is not null")
       .select(inColumns:_*)
@@ -64,7 +66,7 @@ object DNSSuspiciousConnectsAnalysis {
       DNSSuspiciousConnectsModel.trainNewModel(sparkContext, sqlContext, logger, config, rawDataDF, config.topicCount)
 
     logger.info("Scoring")
-    val scoredDF = model.score(sparkContext, sqlContext, rawDataDF)
+    val scoredDF = model.score(sparkContext, sqlContext, rawDataDF, userDomain)
 
 
     val filteredDF = scoredDF.filter(Score + " <= " + config.threshold)

--- a/spot-ml/src/main/scala/org/apache/spot/dns/DNSWordCreation.scala
+++ b/spot-ml/src/main/scala/org/apache/spot/dns/DNSWordCreation.scala
@@ -15,13 +15,15 @@ import org.apache.spot.utilities.Quantiles
   * @param entropyCuts
   * @param numberPeriodsCuts
   * @param topDomainsBC
+  * @param userDomain
   */
 class DNSWordCreation(frameLengthCuts: Array[Double],
                       timeCuts: Array[Double],
                       subdomainLengthCuts: Array[Double],
                       entropyCuts: Array[Double],
                       numberPeriodsCuts: Array[Double],
-                      topDomainsBC: Broadcast[Set[String]]) extends Serializable {
+                      topDomainsBC: Broadcast[Set[String]],
+                      userDomain: String) extends Serializable {
 
 
   /**
@@ -79,7 +81,7 @@ class DNSWordCreation(frameLengthCuts: Array[Double],
 
 
     val DomainInfo(domain, topDomain, subdomain, subdomainLength, subdomainEntropy, numPeriods) =
-      extractDomainInfo(queryName, topDomainsBC)
+      extractDomainInfo(queryName, topDomainsBC, userDomain)
 
     Seq(topDomain,
       Quantiles.bin(frameLength.toDouble, frameLengthCuts),

--- a/spot-ml/src/main/scala/org/apache/spot/dns/model/DNSScoreFunction.scala
+++ b/spot-ml/src/main/scala/org/apache/spot/dns/model/DNSScoreFunction.scala
@@ -8,15 +8,16 @@ import org.apache.spot.dns.DNSWordCreation
 /**
   * Estimate the probabilities of network events using a [[DNSSuspiciousConnectsModel]]
   *
-  * @param frameLengthCuts
-  * @param timeCuts
-  * @param subdomainLengthCuts
-  * @param entropyCuts
-  * @param numberPeriodsCuts
-  * @param topicCount
-  * @param ipToTopicMixBC
-  * @param wordToPerTopicProbBC
-  * @param topDomainsBC
+  * @param frameLengthCuts Delimeters used to define binning for frame length field
+  * @param timeCuts Delimeters used to define binning for time field
+  * @param subdomainLengthCuts Delimeters used to define binning for subdomain length field
+  * @param entropyCuts Delimeters used to define binning for entropy field
+  * @param numberPeriodsCuts Delimeters used to define binning for number of periods of subdomain field
+  * @param topicCount Number of topics used for the LDA model
+  * @param ipToTopicMixBC Topic mixes learned by the LDA model for each IP in the data
+  * @param wordToPerTopicProbBC Word mixes for each of the topics learned by the LDA model
+  * @param topDomainsBC Alexa top one million list of domains.
+  * @param userDomain Domain associated to network data (example: 'intel')
   */
 class DNSScoreFunction(frameLengthCuts: Array[Double],
                        timeCuts: Array[Double],
@@ -26,13 +27,20 @@ class DNSScoreFunction(frameLengthCuts: Array[Double],
                        topicCount: Int,
                        ipToTopicMixBC: Broadcast[Map[String, Array[Double]]],
                        wordToPerTopicProbBC: Broadcast[Map[String, Array[Double]]],
-                       topDomainsBC: Broadcast[Set[String]]) extends Serializable {
+                       topDomainsBC: Broadcast[Set[String]],
+                       userDomain: String) extends Serializable {
 
 
   val suspiciousConnectsScoreFunction =
     new SuspiciousConnectsScoreFunction(topicCount, ipToTopicMixBC, wordToPerTopicProbBC)
 
-  val dnsWordCreator = new DNSWordCreation(frameLengthCuts, timeCuts, subdomainLengthCuts, entropyCuts, numberPeriodsCuts, topDomainsBC)
+  val dnsWordCreator = new DNSWordCreation(frameLengthCuts,
+                                           timeCuts,
+                                           subdomainLengthCuts,
+                                           entropyCuts,
+                                           numberPeriodsCuts,
+                                           topDomainsBC,
+                                           userDomain)
 
   def score(timeStamp: String,
             unixTimeStamp: Long,

--- a/spot-ml/src/main/scala/org/apache/spot/dns/model/DNSSuspiciousConnectsModel.scala
+++ b/spot-ml/src/main/scala/org/apache/spot/dns/model/DNSSuspiciousConnectsModel.scala
@@ -158,6 +158,7 @@ object DNSSuspiciousConnectsModel {
 
     val countryCodesBC = sparkContext.broadcast(CountryCodes.CountryCodes)
     val topDomainsBC = sparkContext.broadcast(TopDomains.TopDomains)
+    val userDomain = config.userDomain
 
     // create quantile cut-offs
 
@@ -181,7 +182,13 @@ object DNSSuspiciousConnectsModel {
 
     // simplify DNS log entries into "words"
 
-    val dnsWordCreator = new DNSWordCreation(frameLengthCuts, timeCuts, subdomainLengthCuts, entropyCuts, numberPeriodsCuts, topDomainsBC)
+    val dnsWordCreator = new DNSWordCreation(frameLengthCuts,
+                                             timeCuts,
+                                             subdomainLengthCuts,
+                                             entropyCuts,
+                                             numberPeriodsCuts,
+                                             topDomainsBC,
+                                             userDomain)
 
     val dataWithWordDF = totalDataDF.withColumn(Word, dnsWordCreator.wordCreationUDF(modelColumns: _*))
 

--- a/spot-ml/src/main/scala/org/apache/spot/dns/model/DNSSuspiciousConnectsModel.scala
+++ b/spot-ml/src/main/scala/org/apache/spot/dns/model/DNSSuspiciousConnectsModel.scala
@@ -64,10 +64,11 @@ class DNSSuspiciousConnectsModel(inTopicCount: Int,
     * @param sc         Spark Context
     * @param sqlContext Spark SQL context
     * @param inDF       Dataframe of DNS log events, containing at least the columns of [[DNSSuspiciousConnectsModel.ModelSchema]]
+    * @param userDomain Domain associated to network data (ex: 'intel')
     * @return Dataframe with a column named [[org.apache.spot.dns.DNSSchema.Score]] that contains the
     *         probability estimated for the network event at that row
     */
-  def score(sc: SparkContext, sqlContext: SQLContext, inDF: DataFrame): DataFrame = {
+  def score(sc: SparkContext, sqlContext: SQLContext, inDF: DataFrame, userDomain: String): DataFrame = {
 
     val countryCodesBC = sc.broadcast(CountryCodes.CountryCodes)
     val topDomainsBC = sc.broadcast(TopDomains.TopDomains)
@@ -84,7 +85,8 @@ class DNSSuspiciousConnectsModel(inTopicCount: Int,
         topicCount,
         ipToTopicMixBC,
         wordToPerTopicProbBC,
-        topDomainsBC)
+        topDomainsBC,
+        userDomain)
 
 
     val scoringUDF = udf((timeStamp: String,
@@ -168,7 +170,7 @@ object DNSSuspiciousConnectsModel {
     val frameLengthCuts = Quantiles.computeDeciles(totalDataDF.select(FrameLength).rdd
       .map({ case Row(frameLen: Int) => frameLen.toDouble }))
 
-    val domainStatsDF = createDomainStatsDF(sparkContext, sqlContext, countryCodesBC, topDomainsBC, totalDataDF)
+    val domainStatsDF = createDomainStatsDF(sparkContext, sqlContext, countryCodesBC, topDomainsBC, userDomain, totalDataDF)
 
     val subdomainLengthCuts = Quantiles.computeQuintiles(domainStatsDF.filter(SubdomainLength + " > 0")
       .select(SubdomainLength).rdd.map({ case Row(subdomainLength: Int) => subdomainLength.toDouble }))
@@ -247,6 +249,7 @@ object DNSSuspiciousConnectsModel {
     * @param sqlContext     Spark SQL context.
     * @param countryCodesBC Broadcast of the country codes set.
     * @param topDomainsBC   Broadcast of the most-popular domains set.
+    * @param userDomain     Domain associated to network data (ex: 'intel')
     * @param inDF           Incoming dataframe. Schema is expected to provide the field [[QueryName]]
     * @return A new dataframe with the new columns added. The new columns have the schema [[DomainStatsSchema]]
     */
@@ -255,11 +258,12 @@ object DNSSuspiciousConnectsModel {
                           sqlContext: SQLContext,
                           countryCodesBC: Broadcast[Set[String]],
                           topDomainsBC: Broadcast[Set[String]],
+                          userDomain: String,
                           inDF: DataFrame): DataFrame = {
     val queryNameIndex = inDF.schema.fieldNames.indexOf(QueryName)
 
     val domainStatsRDD: RDD[Row] = inDF.rdd.map(row =>
-      Row.fromTuple(createTempFields(countryCodesBC, topDomainsBC, row.getString(queryNameIndex))))
+      Row.fromTuple(createTempFields(countryCodesBC, topDomainsBC, userDomain, row.getString(queryNameIndex))))
 
     sqlContext.createDataFrame(domainStatsRDD, DomainStatsSchema)
   }
@@ -271,15 +275,17 @@ object DNSSuspiciousConnectsModel {
     *
     * @param countryCodesBC Broadcast of the country codes set.
     * @param topDomainsBC   Broadcast of the most-popular domains set.
+    * @param userDomain     Domain associated to network data (ex: 'intel')
     * @param url            URL string to anlayze for domain and subdomain information.
     * @return [[TempFields]]
     */
   def createTempFields(countryCodesBC: Broadcast[Set[String]],
                        topDomainsBC: Broadcast[Set[String]],
+                       userDomain: String,
                        url: String): TempFields = {
 
     val DomainInfo(_, topDomainClass, subdomain, subdomainLength, subdomainEntropy, numPeriods) =
-      DomainProcessor.extractDomainInfo(url, topDomainsBC)
+      DomainProcessor.extractDomainInfo(url, topDomainsBC, userDomain)
 
 
     TempFields(topDomainClass = topDomainClass,

--- a/spot-ml/src/main/scala/org/apache/spot/utilities/DomainProcessor.scala
+++ b/spot-ml/src/main/scala/org/apache/spot/utilities/DomainProcessor.scala
@@ -48,9 +48,10 @@ object DomainProcessor extends Serializable {
     * Extract domain info from a url.
     * @param url Incoming url.
     * @param topDomainsBC Broadcast variable containing the top domains set.
+    * @param userDomain Domain of the spot user (example:'intel').
     * @return New [[DomainInfo]] object containing extracted domain information.
     */
-  def extractDomainInfo(url: String, topDomainsBC: Broadcast[Set[String]]): DomainInfo = {
+  def extractDomainInfo(url: String, topDomainsBC: Broadcast[Set[String]], userDomain: String): DomainInfo = {
 
     val spliturl = url.split('.')
     val numParts = spliturl.length
@@ -64,7 +65,7 @@ object DomainProcessor extends Serializable {
       0
     }
 
-    val topDomainClass = if (domain == "intel") {
+    val topDomainClass = if (domain == userDomain) {
       2
     } else if (topDomainsBC.value contains domain) {
       1

--- a/spot-ml/src/main/scala/org/apache/spot/utilities/DomainProcessor.scala
+++ b/spot-ml/src/main/scala/org/apache/spot/utilities/DomainProcessor.scala
@@ -28,10 +28,10 @@ object DomainProcessor extends Serializable {
 
   /**
     * Commonly extracted domain features.
-    * @param domain Domain (if any) of a url.
-    * @param topDomain Numerical class of domain: 2 for Intel, 1 for Alexa top domains, 0 for others.
-    * @param subdomain Subdomain (if any) in the url.
-    * @param subdomainLength Length of the subdomain. 0 if there is none.
+    * @param domain           Domain (if any) of a url.
+    * @param topDomain        Numerical class of domain: 2 for Intel, 1 for Alexa top domains, 0 for others.
+    * @param subdomain        Subdomain (if any) in the url.
+    * @param subdomainLength  Length of the subdomain. 0 if there is none.
     * @param subdomainEntropy Entropy of the subdomain viewed as a distribution on its character set.
     *                         0 if there is no subdomain.
     * @param numPeriods Number of periods + 1 in the url. (Number of sub-strings where url is split by periods.)
@@ -46,9 +46,9 @@ object DomainProcessor extends Serializable {
 
   /**
     * Extract domain info from a url.
-    * @param url Incoming url.
-    * @param topDomainsBC Broadcast variable containing the top domains set.
-    * @param userDomain Domain of the spot user (example:'intel').
+    * @param url           Incoming url.
+    * @param topDomainsBC  Broadcast variable containing the top domains set.
+    * @param userDomain    Domain of the spot user (example:'intel').
     * @return New [[DomainInfo]] object containing extracted domain information.
     */
   def extractDomainInfo(url: String, topDomainsBC: Broadcast[Set[String]], userDomain: String): DomainInfo = {

--- a/spot-ml/src/test/scala/org/apache/spot/utilities/DomainProcessorTest.scala
+++ b/spot-ml/src/test/scala/org/apache/spot/utilities/DomainProcessorTest.scala
@@ -57,8 +57,10 @@ class DomainProcessorTest extends TestingSparkContextFlatSpec with Matchers {
 
     val topDomains = sparkContext.broadcast(TopDomains.TopDomains)
 
+    val userDomain = "intel"
+
     // case class DerivedFields(topDomain: String, subdomainLength: Double, subdomainEntropy: Double, numPeriods: Double)
-    val result = extractDomainInfo(url, topDomains)
+    val result = extractDomainInfo(url, topDomains, userDomain)
 
     result shouldBe DomainInfo(domain = "None", topDomain = 0, subdomain = "None", subdomainLength = 0, subdomainEntropy = 0, numPeriods = 6)
   }
@@ -69,7 +71,9 @@ class DomainProcessorTest extends TestingSparkContextFlatSpec with Matchers {
 
     val topDomains = sparkContext.broadcast(TopDomains.TopDomains)
 
-    val result = extractDomainInfo(url, topDomains)
+    val userDomain = "intel"
+
+    val result = extractDomainInfo(url, topDomains, userDomain)
 
     result shouldBe DomainInfo(domain = "amazon", topDomain = 1, subdomain = "services",
       subdomainLength = 8, subdomainEntropy = 2.5, numPeriods = 4)
@@ -80,8 +84,9 @@ class DomainProcessorTest extends TestingSparkContextFlatSpec with Matchers {
     val url = "amazon.com.mx"
     val countryCodes = sparkContext.broadcast(countryCodesSet)
     val topDomains = sparkContext.broadcast(TopDomains.TopDomains)
+    val userDomain = "intel"
 
-    val result = extractDomainInfo(url, topDomains)
+    val result = extractDomainInfo(url, topDomains, userDomain)
 
     result shouldBe DomainInfo(domain = "amazon", subdomain = "None", topDomain = 1, subdomainLength = 0, subdomainEntropy = 0, numPeriods = 3)
   }
@@ -91,8 +96,9 @@ class DomainProcessorTest extends TestingSparkContextFlatSpec with Matchers {
     val url = "services.amazon.com"
     val countryCodes = sparkContext.broadcast(countryCodesSet)
     val topDomains = sparkContext.broadcast(TopDomains.TopDomains)
+    val userDomain = "intel"
 
-    val result = extractDomainInfo(url, topDomains)
+    val result = extractDomainInfo(url, topDomains, userDomain)
 
     result shouldBe DomainInfo(domain = "amazon", subdomain = "services", topDomain = 1, subdomainLength = 8, subdomainEntropy = 2.5, numPeriods = 3)
   }
@@ -103,7 +109,9 @@ class DomainProcessorTest extends TestingSparkContextFlatSpec with Matchers {
     val url = "amazon.com"
     val countryCodes = sparkContext.broadcast(countryCodesSet)
     val topDomains = sparkContext.broadcast(TopDomains.TopDomains)
-    val result = extractDomainInfo(url, topDomains)
+    val userDomain = "intel"
+
+    val result = extractDomainInfo(url, topDomains, userDomain)
 
     result shouldBe DomainInfo(domain = "amazon", subdomain = "None", topDomain = 1, subdomainLength = 0, subdomainEntropy = 0, numPeriods = 2)
   }

--- a/spot-setup/spot.conf
+++ b/spot-setup/spot.conf
@@ -17,6 +17,7 @@ HPATH=${HUSER}/${DSOURCE}/scored_results/${FDATE}
 #impala config
 IMPALA_DEM='node04'
 
+#kerberos config
 KRB_AUTH=false
 KINITPATH=
 KINITOPTS=
@@ -29,6 +30,9 @@ LPATH=${LUSER}/ml/${DSOURCE}/${FDATE}
 RPATH=${LUSER}/ipython/user/${FDATE}
 LDAPATH=${LUSER}/ml/oni-lda-c
 LIPATH=${LUSER}/ingest
+
+#domain associated to network data to be analyzed
+USER_DOMAIN='intel'
 
 SPK_EXEC='400'
 SPK_EXEC_MEM='2048m'


### PR DESCRIPTION
When we look at DNS logs we call 'domain' the last piece of the url once you remove any country code and top level domain: like com, net etc.) The word create scheme for DNS logs at one point tests whether or not the domain of the DNS query matches the 'user domain' - which is the domain associated to the network from which data is collected.

This test was previously hard coded as a test against the string "intel". I made changes so that the user domain is designated in spot.conf and passed into the argument parser - from there being passed into the appropriate places where it is used.  